### PR TITLE
Added drag and drop functionality to pieces

### DIFF
--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -80,7 +80,7 @@ hgroup.landing-text h4 {
 
   border-collapse: collapse;
   margin: 0 auto;
-  padding-top: 40px;
+  padding-top: 45px;
   background-color: brown;
   border: 1px solid #000000;
   width: auto;
@@ -90,8 +90,8 @@ hgroup.landing-text h4 {
   }
 
   td {
-    width: 40px;
-    height: 40px;
+    width: 45px;
+    height: 45px;
   }
 
   tr:nth-child(even) td:nth-child(even), tr:nth-child(odd) td:nth-child(odd) {

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -8,9 +8,10 @@ class PiecesController < ApplicationController
 
   def update
     @piece = Piece.find(params[:id])
-    @game = @piece.game
+    @game = @piece.game_id
     @piece.update_attributes(piece_params)
-    redirect_to games_path(@game)
+    render json: nil, status: :ok
+    #redirect_to game_path(@game)
   end
 
   private

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,1 +1,56 @@
+<br /><br />
+
 <%= render 'shared/gameboard' %>
+
+<script>
+  $(function() {
+    
+    $('td a').click(function(ev) {
+      ev.preventDefault();
+    });
+
+    $('td a').mousedown(function() {
+      $('td a').not(this).css('z-index', '100');
+      $(this).css('z-index', '1000');
+      $('.highlight').removeClass("highlight");
+      $(this).parent().addClass("highlight");
+    });
+
+    $('td a').draggable({
+      start: function(ev, ui) {  
+        $('.ui-droppable').each(function(i, el) {
+          if (!$(el).find('.ui-draggable').length){
+            $(el).droppable('enable');
+          }
+          else {
+            $(el).droppable('disable');
+          }
+        });
+      },
+      revert: "invalid"
+    });
+
+    $('td').droppable({
+      drop: function(ev, ui) {
+        var dropped = ui.draggable;
+        var droppedOn = $(this);
+        $(dropped).detach().css({top: 0,left: 0}).appendTo(droppedOn);
+        droppedOn.addClass("highlight");
+        $(ev['target']).droppable('disable');
+        var pieceLink = dropped.attr("href");
+        var x = droppedOn.data("x-position");
+        var y = droppedOn.data("y-position");
+
+        $.post(pieceLink, {
+          _method: "PUT",
+          piece: {
+            current_position_x: x,
+            current_position_y: y
+          }
+        });
+      }
+    });
+
+  });
+
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
+  <%= favicon_link_tag 'white-king.png' %>
+  <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
 </head>
 <body>
 

--- a/app/views/shared/_gameboard.html.erb
+++ b/app/views/shared/_gameboard.html.erb
@@ -3,7 +3,7 @@
 		<% (0..7).each do |row| %>
 			<tr class='y-position-<%= row %>'>
 				<% (0..7).each do |column| %>
-					<td class='x-position-<%= column %>' data-x-position='<%= row %>' data-y-position='<%= column %>' >
+					<td class='x-position-<%= column %>' data-x-position='<%= column %>' data-y-position='<%= row %>' >
 
 						<%# TODO: Display gameboard from black_user_id perspective %>
 						<% query_result = @game.pieces.where(current_position_x:column, current_position_y: row).last %>


### PR DESCRIPTION
I struggled with this one a little bit, but I'm pretty happy with how it turned out, and everything seems to be working. I added the jquery to allow the pieces to be dragged and dropped, and I made sure to trigger the update action when a piece is moved. So now the page doesn't refresh between moves, but if you do refresh the page all the changes remain updated. I didn't put any checks to see if it is an actual valid move, I don't think it is ready for that yet, so you can move any piece any way right now.
I also changed the highlight to reflect the last move's starting and end position or if you just click on a piece it will just highlight that piece's square without the interstitial page. I also made some minor fix to make the gameboard appear properly. 

And the last thing I did was change the favicon(the icon in the tab) to be the white king.

Let me know if you have questions, but I do plan to add some comments and tests at some point in the future.
