### PR TITLE
Refactor pawn logic

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,12 +1,11 @@
 class Pawn < Piece
   def valid_move?(move_to_x, move_to_y)
-    return false unless super && !obstructed?(move_to_x, move_to_y)
-    return false if current_position_x != move_to_x 
+    return false unless super
+    return false if current_position_x != move_to_x unless capture?(move_to_x, move_to_y)
     if has_moved
       if color == 'white' && (current_position_y - move_to_y) == 1
         true
-      elsif          
-        color == 'black' && (move_to_y - current_position_y) == 1
+      elsif color == 'black' && (move_to_y - current_position_y) == 1
         true
       else
         false
@@ -14,12 +13,23 @@ class Pawn < Piece
     else
       if color == 'white' && (1..2) === (current_position_y - move_to_y)
         true
-      elsif
-        color == 'black' && (1..2) === (move_to_y - current_position_y) 
+      elsif color == 'black' && (1..2) === (move_to_y - current_position_y) 
         true
       else
         false      
       end
     end      
   end
+
+  def capture?(move_to_x, move_to_y)
+    capture_piece = game.pieces.find_by(current_position_x: move_to_x, current_position_y: move_to_y)
+    if capture_piece && capture_piece.color != color
+      if (current_position_x - move_to_x) == 1 || (current_position_x - move_to_x) == -1
+        true
+      else
+        false
+      end
+    end
+  end
 end
+

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,24 +1,25 @@
 class Pawn < Piece
   def valid_move?(move_to_x, move_to_y)
-    return false if (current_position_x - move_to_x).abs != 0 
-    if has_moved == true
-      if color == 'white' && (current_position_y - move_to_y) == 1 
-        return true
-      elsif 
-        color == 'black' && (current_position_y - move_to_y) == -1
-        return true
+    return false unless super && !obstructed?(move_to_x, move_to_y)
+    return false if current_position_x != move_to_x 
+    if has_moved
+      if color == 'white' && (current_position_y - move_to_y) == 1
+        true
+      elsif          
+        color == 'black' && (move_to_y - current_position_y) == 1
+        true
       else
-        return false
-      end
+        false
+      end 
     else
       if color == 'white' && (1..2) === (current_position_y - move_to_y)
-        return true
-      elsif 
-        color == 'black' && (current_position_y - move_to_y) == -1 || (current_position_y - move_to_y) == -2
-        return true
+        true
+      elsif
+        color == 'black' && (1..2) === (move_to_y - current_position_y) 
+        true
       else
-        return false
-      end      
-    end
+        false      
+      end
+    end      
   end
 end


### PR DESCRIPTION
I had to leave out the obstructed? method in order for my pawn logic to work correctly. Initially I had return false unless super && !obstructed?(move_to_x, move_to_y). That caused some pawns to not be able to move two squares on the first move. After I removed the obstructed? method, the pawn logic worked correctly. I'm not sure if the obstructed? method is causing the issue.

The second issue I have is with the pawn capture. I wrote the logic to allow it to capture pieces diagonally, but somehow it's still capturing pieces in front. I'm wondering if the moved_toI method is overwriting the pawn capture logic. I'll keep looking into it, but feel free to help me troubleshoot. :-) 
