### PR TITLE
Add ability to make castle moves

### DIFF
--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,7 +1,13 @@
 class King < Piece
+
+  def castle_move
+    update_attributes(current_position_x: @new_king_x, current_position_y: current_position_y, has_moved: true)
+    @castle_rook.update_attributes(current_position_x: @new_rook_x, current_position_y: current_position_y, has_moved: true)
+  end
+
   def valid_move?(move_to_x, move_to_y)
     # Range of king is <= 1 unless the king is castlling
-    if super && (proper_length?(move_to_x, move_to_y) || (castling?(move_to_x, move_to_y) && !obstructed(move_to_x, move_to_y)))
+    if super && (proper_length?(move_to_x, move_to_y) || (castling?(move_to_x, move_to_y) && !obstructed?(move_to_x, move_to_y)))
       return true
     else
       return false
@@ -16,43 +22,57 @@ class King < Piece
   end
 
   def castling?(x, y)
-    # if king is currently in check, castling is false
-    # if king would castle in to check, castling is false
-    # if king would castle through check, castling is false
-    # if king has moved or rook has moved, castling is false
     x_difference = current_position_x - x
+
+    return false unless has_moved == false
+    return false unless x_difference.abs == 2
+    return false unless y == current_position_y
 
     # Queenside
     if x < self.current_position_x
-      queenside_rook = Piece.find_by(type: 'Rook', current_position_x: 0, current_position_y: y)
-      if queenside_rook.present?
-        # if king and rook havn't moved
-        if self.has_moved == false && queenside_rook.has_moved == false
-          # king moves excatly 2 squares horizontally
-          if x_difference.abs == 2 && y == current_position_y
-            return true
-          else
-            return false
-          end
-        end
-      else
-      end
+      @castle_rook = get_rook_for_castle('Queen')
+      @new_king_x = 2
+      @new_rook_x = 3
+    else
+      # Kingside
+      @castle_rook = get_rook_for_castle('King')
+      @new_king_x = 6
+      @new_rook_x = 5
     end
 
-    if x > self.current_position_x
-      kingside_rook = Piece.find_by(type: 'Rook', current_position_x: 7, current_position_y: y)
-      # if king and rook havn't moved
-      if kingside_rook.present?
-        if self.has_moved == false && kingside_rook.has_moved == false
-          # king moves excatly 2 squares horizontally
-          if x_difference.abs == 2 && y == current_position_y
-            return true
-          else
-            return false
-          end
-        end
-      else
-      end
+    return false if @castle_rook.nil?
+
+    return false unless @castle_rook.has_moved == false
+
+    true
+  end
+
+  def move_to!(x, y)
+    if valid_move?(x, y) && castling?(x, y)
+      castle_move
+    else
+      super(x, y)
+    end
+  end
+
+  def get_rook_for_castle(side)
+    case side
+    when 'King'
+      game.pieces.find_by(
+        type: 'Rook',
+        current_position_x: 7,
+        current_position_y: current_position_y
+      )
+
+    when 'Queen'
+      game.pieces.find_by(
+        type: 'Rook',
+        current_position_x: 0,
+        current_position_y: current_position_y
+      )
+
+    else
+      return nil
     end
   end
 end


### PR DESCRIPTION
@MarcMcArthur suggested I submit my two branches as pull requests, even though they aren't quite finished. This branch finished the castling functionality aside from the JS update. If castling is a valid move, dragging either King two squares right or left will allow you to drop him there, but the Rook will remain in the same position until after a page refresh. Marc and I have been unable to decipher the JavaScript well enough to figure out exactly what changes are required - it seems to me that because our JS only works for dragging and dropping, pieces that aren't actually selected will not be updated. Not sure if they will require an entire JS refactoring or what. @jackpip let me know if you have any thoughts on this, as I think you have the best grasp of the JS logic in our app.
